### PR TITLE
Adding gyro and accelerometer variances to IMU output message

### DIFF
--- a/AirSim/AirLib/include/api/RpcLibAdapatorsBase.hpp
+++ b/AirSim/AirLib/include/api/RpcLibAdapatorsBase.hpp
@@ -506,6 +506,7 @@ public:
         Quaternionr orientation;
         Vector3r angular_velocity;
         Vector3r linear_acceleration;
+        msr::airlib::real_T sigma_arw, sigma_vrw;
 
         MSGPACK_DEFINE_MAP(time_stamp, orientation, angular_velocity, linear_acceleration);
 
@@ -518,6 +519,8 @@ public:
             orientation = s.orientation;
             angular_velocity = s.angular_velocity;
             linear_acceleration = s.linear_acceleration;
+            sigma_arw = s.sigma_arw;
+            sigma_vrw = s.sigma_vrw;
         }
 
         msr::airlib::ImuBase::Output to() const
@@ -528,6 +531,8 @@ public:
             d.orientation = orientation.to();
             d.angular_velocity = angular_velocity.to();
             d.linear_acceleration = linear_acceleration.to();
+            d.sigma_vrw = sigma_vrw;
+            d.sigma_arw = sigma_arw;
 
             return d;
         }

--- a/AirSim/AirLib/include/api/RpcLibAdapatorsBase.hpp
+++ b/AirSim/AirLib/include/api/RpcLibAdapatorsBase.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) Mizosoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 #ifndef air_RpcLibAdapatorsBase_hpp

--- a/AirSim/AirLib/include/api/RpcLibAdapatorsBase.hpp
+++ b/AirSim/AirLib/include/api/RpcLibAdapatorsBase.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Mizosoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 #ifndef air_RpcLibAdapatorsBase_hpp
@@ -508,7 +508,7 @@ public:
         Vector3r linear_acceleration;
         msr::airlib::real_T sigma_arw, sigma_vrw;
 
-        MSGPACK_DEFINE_MAP(time_stamp, orientation, angular_velocity, linear_acceleration);
+        MSGPACK_DEFINE_MAP(time_stamp, orientation, angular_velocity, linear_acceleration, sigma_arw, sigma_vrw);
 
         ImuData()
         {}

--- a/AirSim/AirLib/include/sensors/imu/ImuBase.hpp
+++ b/AirSim/AirLib/include/sensors/imu/ImuBase.hpp
@@ -6,6 +6,7 @@
 
 
 #include "sensors/SensorBase.hpp"
+#include "common/Common.hpp"
 
 
 namespace msr { namespace airlib {

--- a/AirSim/AirLib/include/sensors/imu/ImuBase.hpp
+++ b/AirSim/AirLib/include/sensors/imu/ImuBase.hpp
@@ -22,6 +22,7 @@ public: //types
         TTimePoint time_stamp; 
         Quaternionr orientation;
         Vector3r angular_velocity;
+        real_T sigma_arw, sigma_vrw;
         Vector3r linear_acceleration;
     };
 

--- a/AirSim/AirLib/include/sensors/imu/ImuSimple.hpp
+++ b/AirSim/AirLib/include/sensors/imu/ImuSimple.hpp
@@ -61,12 +61,9 @@ private: //methods
 
         //add noise
         addNoise(output.linear_acceleration, output.angular_velocity);
-        output.sigma_arw=sigma_gyro_out;
-        output.sigma_vrw=sigma_accel_out;
         // TODO: Add noise in orientation?
 
         output.time_stamp = clock()->nowNanos();
-
         setOutput(output);
     }
 
@@ -86,7 +83,7 @@ private: //methods
         //update bias random walk
         real_T gyro_sigma_bias = gyro_bias_stability_norm * sqrt_dt;
         state_.gyroscope_bias += gauss_dist.next() * gyro_sigma_bias;
-        sigma_gyro_out= gyro_sigma_arw; // Not 100% sure about this - as you are accumulating error through bias, the bias' std devs also accumulate, so it was chosen not to include the accumulating std deviation of the bias in the covariance matrix
+        sigma_gyro_out = gyro_sigma_arw; // Not 100% sure about this - as you are accumulating error through bias, the bias' std devs also accumulate, so it was chosen not to include the accumulating std deviation of the bias in the covariance matrix
 
         //accelerometer
         //convert vrw to stddev
@@ -99,13 +96,15 @@ private: //methods
     }
 
 
+public:
+    real_T sigma_gyro_out, sigma_accel_out;
+
 private: //fields
     ImuSimpleParams params_;
     RandomVectorGaussianR gauss_dist = RandomVectorGaussianR(0, 1);
 
     //cached calculated values
     real_T gyro_bias_stability_norm, accel_bias_stability_norm;
-    real_T sigma_gyro_out, sigma_accel_out;
     struct State {
         Vector3r gyroscope_bias;
         Vector3r accelerometer_bias;

--- a/AirSim/AirLib/include/sensors/imu/ImuSimple.hpp
+++ b/AirSim/AirLib/include/sensors/imu/ImuSimple.hpp
@@ -61,7 +61,8 @@ private: //methods
 
         //add noise
         addNoise(output.linear_acceleration, output.angular_velocity);
-
+        output.sigma_arw=sigma_gyro_out;
+        output.sigma_vrw=sigma_accel_out;
         // TODO: Add noise in orientation?
 
         output.time_stamp = clock()->nowNanos();
@@ -85,7 +86,7 @@ private: //methods
         //update bias random walk
         real_T gyro_sigma_bias = gyro_bias_stability_norm * sqrt_dt;
         state_.gyroscope_bias += gauss_dist.next() * gyro_sigma_bias;
-        sigma_gyro_out= gyro_sigma_arw + gyro_sigma_bias; // Not 100% sure about this, as you are accumulating error through bias, the bias' std devs also accumulate
+        sigma_gyro_out= gyro_sigma_arw; // Not 100% sure about this - as you are accumulating error through bias, the bias' std devs also accumulate, so it was chosen not to include the accumulating std deviation of the bias in the covariance matrix
 
         //accelerometer
         //convert vrw to stddev
@@ -94,7 +95,7 @@ private: //methods
         //update bias random walk
         real_T accel_sigma_bias = accel_bias_stability_norm * sqrt_dt;
         state_.accelerometer_bias += gauss_dist.next() * accel_sigma_bias;
-        sigma_accel_out = accel_sigma_vrw + accel_sigma_bias;
+        sigma_accel_out = accel_sigma_vrw; 
     }
 
 

--- a/AirSim/AirLib/include/sensors/imu/ImuSimple.hpp
+++ b/AirSim/AirLib/include/sensors/imu/ImuSimple.hpp
@@ -64,6 +64,8 @@ private: //methods
         // TODO: Add noise in orientation?
 
         output.time_stamp = clock()->nowNanos();
+        output.sigma_arw = sigma_gyro_out;
+        output.sigma_vrw = sigma_accel_out;
         setOutput(output);
     }
 
@@ -83,7 +85,7 @@ private: //methods
         //update bias random walk
         real_T gyro_sigma_bias = gyro_bias_stability_norm * sqrt_dt;
         state_.gyroscope_bias += gauss_dist.next() * gyro_sigma_bias;
-        sigma_gyro_out = gyro_sigma_arw; // Not 100% sure about this - as you are accumulating error through bias, the bias' std devs also accumulate, so it was chosen not to include the accumulating std deviation of the bias in the covariance matrix
+        sigma_gyro_out = gyro_sigma_arw + gyro_sigma_bias; // Not 100% sure about this - as you are accumulating error through bias, the bias' std devs also accumulate, so I chose to include the accumulating std deviation of the bias in the covariance matrix
 
         //accelerometer
         //convert vrw to stddev
@@ -92,7 +94,7 @@ private: //methods
         //update bias random walk
         real_T accel_sigma_bias = accel_bias_stability_norm * sqrt_dt;
         state_.accelerometer_bias += gauss_dist.next() * accel_sigma_bias;
-        sigma_accel_out = accel_sigma_vrw; 
+        sigma_accel_out = accel_sigma_vrw + accel_sigma_bias; 
     }
 
 

--- a/AirSim/AirLib/include/sensors/imu/ImuSimple.hpp
+++ b/AirSim/AirLib/include/sensors/imu/ImuSimple.hpp
@@ -61,6 +61,7 @@ private: //methods
 
         //add noise
         addNoise(output.linear_acceleration, output.angular_velocity);
+
         // TODO: Add noise in orientation?
 
         output.time_stamp = clock()->nowNanos();
@@ -84,6 +85,7 @@ private: //methods
         //update bias random walk
         real_T gyro_sigma_bias = gyro_bias_stability_norm * sqrt_dt;
         state_.gyroscope_bias += gauss_dist.next() * gyro_sigma_bias;
+        sigma_gyro_out= gyro_sigma_arw + gyro_sigma_bias; // Not 100% sure about this, as you are accumulating error through bias, the bias' std devs also accumulate
 
         //accelerometer
         //convert vrw to stddev
@@ -92,6 +94,7 @@ private: //methods
         //update bias random walk
         real_T accel_sigma_bias = accel_bias_stability_norm * sqrt_dt;
         state_.accelerometer_bias += gauss_dist.next() * accel_sigma_bias;
+        sigma_accel_out = accel_sigma_vrw + accel_sigma_bias;
     }
 
 
@@ -101,7 +104,7 @@ private: //fields
 
     //cached calculated values
     real_T gyro_bias_stability_norm, accel_bias_stability_norm;
-
+    real_T sigma_gyro_out, sigma_accel_out;
     struct State {
         Vector3r gyroscope_bias;
         Vector3r accelerometer_bias;

--- a/AirSim/AirLib/src/api/RpcLibServerBase.cpp
+++ b/AirSim/AirLib/src/api/RpcLibServerBase.cpp
@@ -20,7 +20,7 @@ STRICT_MODE_OFF
 
 #include "common/common_utils/WindowsApisCommonPre.hpp"
 #undef FLOAT
-#undef checkx
+#undef check
 #include "rpc/server.h"
 //TODO: HACK: UE4 defines macro with stupid names like "check" that conflicts with msgpack library
 #ifndef check

--- a/AirSim/AirLib/src/api/RpcLibServerBase.cpp
+++ b/AirSim/AirLib/src/api/RpcLibServerBase.cpp
@@ -20,7 +20,7 @@ STRICT_MODE_OFF
 
 #include "common/common_utils/WindowsApisCommonPre.hpp"
 #undef FLOAT
-#undef check
+#undef checkx
 #include "rpc/server.h"
 //TODO: HACK: UE4 defines macro with stupid names like "check" that conflicts with msgpack library
 #ifndef check

--- a/ros/src/fsds_ros_bridge/src/airsim_ros_wrapper.cpp
+++ b/ros/src/fsds_ros_bridge/src/airsim_ros_wrapper.cpp
@@ -387,12 +387,6 @@ sensor_msgs::Imu AirsimROSWrapper::get_imu_msg_from_airsim(const msr::airlib::Im
 
     imu_msg.header.stamp = make_ts(imu_data.time_stamp);
     // imu_msg.orientation_covariance = ;
-    imu_msg.angular_velocity_covariance[0] = imu_data.sigma_arw*imu_data.sigma_arw;
-    imu_msg.angular_velocity_covariance[4] = imu_data.sigma_arw*imu_data.sigma_arw;
-    imu_msg.angular_velocity_covariance[8] = imu_data.sigma_arw*imu_data.sigma_arw;
-    imu_msg.linear_acceleration_covariance[0] = imu_data.sigma_vrw*imu_data.sigma_vrw;
-    imu_msg.linear_acceleration_covariance[4] = imu_data.sigma_vrw*imu_data.sigma_vrw;
-    imu_msg.linear_acceleration_covariance[8] = imu_data.sigma_vrw*imu_data.sigma_vrw;
 
     return imu_msg;
 }
@@ -497,6 +491,12 @@ void AirsimROSWrapper::imu_timer_cb(const ros::TimerEvent& event)
         }
 
         sensor_msgs::Imu imu_msg = get_imu_msg_from_airsim(imu_data);
+        imu_msg.angular_velocity_covariance[0] = imu_data.sigma_arw*imu_data.sigma_arw;
+        imu_msg.angular_velocity_covariance[4] = imu_data.sigma_arw*imu_data.sigma_arw;
+        imu_msg.angular_velocity_covariance[8] = imu_data.sigma_arw*imu_data.sigma_arw;
+        imu_msg.linear_acceleration_covariance[0] = imu_data.sigma_vrw*imu_data.sigma_vrw;
+        imu_msg.linear_acceleration_covariance[4] = imu_data.sigma_vrw*imu_data.sigma_vrw;
+        imu_msg.linear_acceleration_covariance[8] = imu_data.sigma_vrw*imu_data.sigma_vrw;
         imu_msg.header.frame_id = "fsds/" + vehicle_name;
         // imu_msg.header.stamp = ros::Time::now();
         {

--- a/ros/src/fsds_ros_bridge/src/airsim_ros_wrapper.cpp
+++ b/ros/src/fsds_ros_bridge/src/airsim_ros_wrapper.cpp
@@ -491,7 +491,7 @@ void AirsimROSWrapper::imu_timer_cb(const ros::TimerEvent& event)
         }
 
         sensor_msgs::Imu imu_msg = get_imu_msg_from_airsim(imu_data);
-        imu_msg.angular_velocity_covariance[0] = imu_data.sigma_arw*imu_data.sigma_arw;
+        imu_msg.angular_velocity_covariance[0] = imu_data.sigma_arw*imu_data.sigma_arw; 
         imu_msg.angular_velocity_covariance[4] = imu_data.sigma_arw*imu_data.sigma_arw;
         imu_msg.angular_velocity_covariance[8] = imu_data.sigma_arw*imu_data.sigma_arw;
         imu_msg.linear_acceleration_covariance[0] = imu_data.sigma_vrw*imu_data.sigma_vrw;

--- a/ros/src/fsds_ros_bridge/src/airsim_ros_wrapper.cpp
+++ b/ros/src/fsds_ros_bridge/src/airsim_ros_wrapper.cpp
@@ -387,8 +387,12 @@ sensor_msgs::Imu AirsimROSWrapper::get_imu_msg_from_airsim(const msr::airlib::Im
 
     imu_msg.header.stamp = make_ts(imu_data.time_stamp);
     // imu_msg.orientation_covariance = ;
-    // imu_msg.angular_velocity_covariance = ;
-    // imu_msg.linear_acceleration_covariance = ;
+    imu_msg.angular_velocity_covariance[0] = imu_data.sigma_arw*imu_data.sigma_arw;
+    imu_msg.angular_velocity_covariance[4] = imu_data.sigma_arw*imu_data.sigma_arw;
+    imu_msg.angular_velocity_covariance[8] = imu_data.sigma_arw*imu_data.sigma_arw;
+    imu_msg.linear_acceleration_covariance[0] = imu_data.sigma_vrw*imu_data.sigma_vrw;
+    imu_msg.linear_acceleration_covariance[4] = imu_data.sigma_vrw*imu_data.sigma_vrw;
+    imu_msg.linear_acceleration_covariance[8] = imu_data.sigma_vrw*imu_data.sigma_vrw;
 
     return imu_msg;
 }


### PR DESCRIPTION
#130 
Fixes and populates the of IMU's gyro and accelerometer variances. Also includes the accumulating bias error - depending on performance, a revision potentially required to only account for the Gaussian noise part within covariance matrices of gyro and acce
