### PR TITLE
Lidar realistic rules, simplify capture configuration and improved documentation.

### DIFF
--- a/AirSim/AirLib/include/common/AirSimSettings.hpp
+++ b/AirSim/AirLib/include/common/AirSimSettings.hpp
@@ -202,9 +202,9 @@ public: //types
     struct LidarSetting : SensorSetting {
 
         // shared defaults
-        uint number_of_channels = 16;
+        uint number_of_lasers = 16;
         real_T range = 10000.0f / 100;                    // meters
-        uint points_per_second = 100000;
+        uint points_per_scan = 10000;
         uint horizontal_rotation_frequency = 10;          // rotations/sec
         float horizontal_FOV_start = 0;                   // degrees
         float horizontal_FOV_end = 359;                   // degrees
@@ -1156,9 +1156,9 @@ private:
 
     static void initializeLidarSetting(LidarSetting& lidar_setting, const Settings& settings_json)
     {
-        lidar_setting.number_of_channels = settings_json.getInt("NumberOfChannels", lidar_setting.number_of_channels);
+        lidar_setting.number_of_lasers = settings_json.getInt("NumberOfLasers", lidar_setting.number_of_lasers);
         lidar_setting.range = settings_json.getFloat("Range", lidar_setting.range);
-        lidar_setting.points_per_second = settings_json.getInt("PointsPerSecond", lidar_setting.points_per_second);
+        lidar_setting.points_per_scan = settings_json.getInt("PointsPerScan", lidar_setting.points_per_scan);
         lidar_setting.horizontal_rotation_frequency = settings_json.getInt("RotationsPerSecond", lidar_setting.horizontal_rotation_frequency);
         lidar_setting.draw_debug_points = settings_json.getBool("DrawDebugPoints", lidar_setting.draw_debug_points);
 

--- a/AirSim/AirLib/include/sensors/lidar/LidarSimple.hpp
+++ b/AirSim/AirLib/include/sensors/lidar/LidarSimple.hpp
@@ -22,7 +22,7 @@ public:
         params_.initializeFromSettings(setting);
 
         //initialize frequency limiter
-        freq_limiter_.initialize(params_.update_frequency, params_.startup_delay);
+        freq_limiter_.initialize(params_.horizontal_rotation_frequency, 0);
     }
 
     //*** Start: UpdatableState implementation ***//
@@ -50,7 +50,7 @@ public:
         //call base
         LidarBase::reportState(reporter);
 
-        reporter.writeValue("Lidar-NumChannels", params_.number_of_channels);
+        reporter.writeValue("Lidar-NumLasers", params_.number_of_lasers);
         reporter.writeValue("Lidar-Range", params_.range);
         reporter.writeValue("Lidar-FOV-Upper", params_.vertical_FOV_upper);
         reporter.writeValue("Lidar-FOV-Lower", params_.vertical_FOV_lower);

--- a/AirSim/AirLib/include/sensors/lidar/LidarSimpleParams.hpp
+++ b/AirSim/AirLib/include/sensors/lidar/LidarSimpleParams.hpp
@@ -11,38 +11,30 @@ namespace msr { namespace airlib {
 
 struct LidarSimpleParams {
 
-    // Velodyne VLP-16 Puck config
-    // https://velodynelidar.com/vlp-16.html
-
-    // default settings
-    // TODO: enable reading of these params from AirSim settings
-
-    uint number_of_channels = 16; 
+    // default values
+    uint number_of_lasers = 16; 
     real_T range = 10000.0f / 100;            // meters
-    uint points_per_second = 100000;  
+    uint points_per_scan = 100000;  
     uint horizontal_rotation_frequency = 10;  // rotations/sec
     real_T horizontal_FOV_start = 0;
     real_T horizontal_FOV_end = 359;
-    real_T vertical_FOV_upper = -15;             // drones -15, car +10
-    real_T vertical_FOV_lower = -45;             // drones -45, car -10
+    real_T vertical_FOV_upper = -15;
+    real_T vertical_FOV_lower = -45;
 
     Pose relative_pose {
-        Vector3r(0,0,-1),                     // position - a little above vehicle (especially for cars) or Vector3r::Zero()
+        Vector3r(0,0,-1),                     // position - a little above vehicle
         Quaternionr::Identity()               // orientation - by default Quaternionr(1, 0, 0, 0) 
         };                       
 
     bool draw_debug_points = false;
 
-    real_T update_frequency = 10;             // Hz
-    real_T startup_delay = 0;                 // sec
-
     void initializeFromSettings(const AirSimSettings::LidarSetting& settings)
     {
         std::string simmode_name = AirSimSettings::singleton().simmode_name;
 
-        number_of_channels = settings.number_of_channels;
+        number_of_lasers = settings.number_of_lasers;
         range = settings.range;
-        points_per_second = settings.points_per_second;
+        points_per_scan = settings.points_per_scan;
         horizontal_rotation_frequency = settings.horizontal_rotation_frequency;
 
         horizontal_FOV_start = settings.horizontal_FOV_start;

--- a/UE4Project/Plugins/AirSim/Source/SimMode/SimModeBase.h
+++ b/UE4Project/Plugins/AirSim/Source/SimMode/SimModeBase.h
@@ -144,9 +144,6 @@ private:
     UPROPERTY()
         TArray<AActor*> spawned_actors_; //keep refs alive from Unreal GC
 
-    bool lidar_checks_done_ = false; 
-    bool lidar_draw_debug_points_ = false;
-
 private:
     void setStencilIDs();
     void initializeTimeOfDay();

--- a/UE4Project/Plugins/AirSim/Source/UnrealSensors/UnrealLidarSensor.h
+++ b/UE4Project/Plugins/AirSim/Source/UnrealSensors/UnrealLidarSensor.h
@@ -37,5 +37,4 @@ private:
     const NedTransform* ned_transform_;
 
     msr::airlib::vector<msr::airlib::real_T> laser_angles_;
-    float current_horizontal_angle_ = 0.0f;
 };

--- a/config/team_config.json
+++ b/config/team_config.json
@@ -32,8 +32,8 @@
                         "LidarCustom": {
                         "SensorType": 6,
                         "Enabled": true,
-                        "NumberOfChannels": 16,
-                        "PointsPerSecond": 10000,
+                        "NumberOfLasers": 16,
+                        "PointsPerScan": 10000,
                         "X": 0,
                         "Y": 0,
                         "Z": -1,
@@ -137,8 +137,8 @@
                         "LidarCustom": {
                         "SensorType": 6,
                         "Enabled": true,
-                        "NumberOfChannels": 16,
-                        "PointsPerSecond": 10000,
+                        "NumberOfLasers": 16,
+                        "PointsPerScan": 10000,
                         "X": 0,
                         "Y": 0,
                         "Z": -1,

--- a/docs/integration-handbook.md
+++ b/docs/integration-handbook.md
@@ -101,41 +101,23 @@ A vehicle can have between 0 and 5 lidars.
 The lidar(s) can be placed anywhere on the vehicle that would be allowed by FSG 2020 rules.
 The body dimension of every lidar is a vertical cylinder, 8 cm height and 8 cm diameter with mounting points at the top and bottom.
 
-A single lidar can have between 1 and 500 lasers. 
-The lasers are stacked vertically and rotate on the horizontal plane. 
-The lasers are distributed equally to cover the specified vertical field of view.
+A single lidar can have between 1 and 128 lasers. 
 
-The vertical field of view is specified by choosing the upper and lower limit in degrees. 
-The lower limit specifies the vertical angle between the horizontal plane of the lidar and the most bottom laser. 
-The upper limit specifies the vertical angle between the horizontal plane of the lidar and most upper laser. 
+The vertical inter-laser angle must be at least 0,18 degrees be no larger than 180 degrees.
 
-The horizontal field of view of the lidar is specified with an upper and lower limit in degree as well. Only points within this FOV will be returned. 
-The lower limit specifies the counterclockwise angle on a top view from the direction the lidar is pointing towards. 
-The upper limit specifies the clockwise angle on a top view from the direction the lidar is pointing towards. 
+The rotation frequency must be between 5 and 20 Hz.
 
-For every lidar, the rotation speed (Hz) and capture frequency (Hz) must be chosen. 
-The rotation speed specifies how fast the lasers spin and the capture frequency specifies how often a point cloud is created.
+For each lidar, during a single rotation, the number of collected points for 1 laser must be not higher than 2048 for 360 degrees.
 
-While rotating, only lasers within the horizontal field of view are captured. 
+The number of collected points per lidar per laser per second cannot exceed 20480.
 
-> For example, a lidar with 190 degrees horizontal field of view, rotating at 10hz with a capture frequency of 20 Hz will receive point clouds covering anything from 10 to 180 degrees of the field of view.
+To ensure the simulation keeps running smoothly:
+* Every lidar is limited to collect 10000 points per scan.
+* The total number of points collected per second can be no larger than 100000
 
-There is no guarantee that the rotation speed and capture frequency stay in sync. 
-You won’t be able to rely on synchronization of rotation speed and capture frequency. 
-A lidar rotating at 5 Hz would theoretically have rotated 50 times after 10 seconds but in reality, this will be somewhere between 45 and 55 times. 
+The range of each laser is 100 meter.
 
-For every lidar, you can specify the resolution: the total number of points collected if the lasers would do a 360 field of view sweep scan. 
-This value is used to calculate the number of points in each laser and the spacing between the points. 
-
-Every lidar capture is limited to collecting 10000 points. 
-The maximum number of points collected during a capture is calculated by dividing the lidar’s resolution by the horizontal field of view fraction.
-
-> For example, a lidar with a 30 degrees horizontal field (horizontal FOV fraction of 30/360 = 1/12) can have a maximum resolution of 120000.
-
-The total number of points per second is limited to 100000 points.
-
-> For example, a first lidar collects 10000 points per capture at 5 hz, a second lidar collects 8000 points per capture at 5 hz. 
-  This is valid because in total they collect 90000 points per second.
+Details on how to configure the lidar sensor can be found [here](lidar.md).
 
 ### GPS
 Every vehicle has 1 GPS, it is located at the centre of gravity of the vehicle.
@@ -162,9 +144,9 @@ You are allowed to configure the following subset of parameters within the bound
  *  * FOV_Degrees (degrees)
  *  * X, Y, Z (meters)
  *  * Pitch, Roll, Yaw (degrees)
-* Lidars
- *  * NumberOfChannels
- *  * PointsPerSecond
+* Lidars (for more details, see [the lidar documentation](lidar.md))
+ *  * NumberOfLasers
+ *  * PointsPerScan
  *  * RotationsPerSecond
  *  * HorizontalFOVStart (degrees)
  *  * HorizontalFOVEnd (degrees)

--- a/docs/lidar.md
+++ b/docs/lidar.md
@@ -1,0 +1,49 @@
+# Lidar
+
+The lidar sensors are configured in the setting.json.
+This is an example lidar:
+
+```
+"Lidar1": {
+    "SensorType": 6,
+    "Enabled": true,
+    "X": 0, "Y": 0, "Z": -1,
+    "Roll": 0, "Pitch": 0, "Yaw" : 0,
+    "NumberOfLasers": 7,
+    "PointsPerScan": 2000,
+    "RotationsPerSecond": 20,
+    "VerticalFOVUpper": 0,
+    "VerticalFOVLower": -25,
+    "HorizontalFOVStart": 0,
+    "HorizontalFOVEnd": 90,
+    "DrawDebugPoints": false
+}
+```
+
+`Lidar1` is the name of the lidar. This value will be used in the ros topic name and coordinate frame.
+
+`X`, `Y` and `Z` are the position of the lidar relative the the center of the car in NED frame.
+
+`Roll`,`Pitch` and `Yaw` are rotations in degrees.
+
+`NumberOfLasers` is the - duh - the number of lasers in the lidar.
+The lasers are stacked vertically and rotate on the horizontal plane. 
+The lasers are distributed equally to cover the specified vertical field of view.
+
+The vertical field of view is specified by choosing the upper (`VerticalFOVUpper`) and lower (`VerticalFOVLower`) limit in degrees. 
+The lower limit specifies the vertical angle between the horizontal plane of the lidar and the most bottom laser. 
+The upper limit specifies the vertical angle between the horizontal plane of the lidar and most upper laser. 
+
+The horizontal field of view of the lidar is specified with an upper (`HorizontalFOVStart`) and lower (`HorizontalFOVEnd`) limit in degree as well.
+The lower limit specifies the counterclockwise angle on a top view (negative yaw) from the direction the lidar is pointing towards.
+The upper limit specifies the clockwise angle on a top view (positive yaw) from the direction the lidar is pointing towards. 
+
+`RotationsPerSecond` specifies how fast the lasers spins and how often a pointcloud is captured.
+There might be slight variations in the actual lidar frequency vs the configured rotation frequency.
+
+`PointsPerScan` is the number of firings per scan within the field of view.
+If all lasers hit, the returned pointcloud will contain this number of points in each pointcloud.
+
+`DrawDebugPoints` enables visualization of the lidar hits inside the unreal engine game.
+This is known to impact performance quite a bit. 
+it is recommended to to only use this during debugging.

--- a/ros/src/fsds_ros_bridge/include/airsim_ros_wrapper.h
+++ b/ros/src/fsds_ros_bridge/include/airsim_ros_wrapper.h
@@ -188,7 +188,7 @@ private:
     ros::Timer odom_update_timer_;
     ros::Timer gps_update_timer_;
     ros::Timer imu_update_timer_;
-    ros::Timer airsim_lidar_update_timer_;
+    std::vector<ros::Timer> airsim_lidar_update_timers_;
     ros::Timer statistics_timer_;
     ros::Timer go_signal_timer_;
     ros::Timer statictf_timer_;

--- a/ros/src/fsds_ros_bridge/include/airsim_ros_wrapper.h
+++ b/ros/src/fsds_ros_bridge/include/airsim_ros_wrapper.h
@@ -122,7 +122,7 @@ private:
     void imu_timer_cb(const ros::TimerEvent& event);
     void statictf_cb(const ros::TimerEvent& event);
     void car_control_cb(const fs_msgs::ControlCommand::ConstPtr& msg, const std::string& vehicle_name);
-    void lidar_timer_cb(const ros::TimerEvent& event);
+    void lidar_timer_cb(const ros::TimerEvent& event, const std::string& camera_name, const int lidar_index);
     void statistics_timer_cb(const ros::TimerEvent& event);
     void go_signal_timer_cb(const ros::TimerEvent& event);
 

--- a/ros/src/fsds_ros_bridge/src/airsim_ros_wrapper.cpp
+++ b/ros/src/fsds_ros_bridge/src/airsim_ros_wrapper.cpp
@@ -10,8 +10,6 @@ AirsimROSWrapper::AirsimROSWrapper(const ros::NodeHandle& nh, const ros::NodeHan
                                                                                                                                airsim_client_(host_ip),
                                                                                                                                airsim_client_lidar_(host_ip)
 {
-    is_used_lidar_timer_cb_queue_ = false;
-
     initialize_statistics();
     initialize_ros();
 
@@ -206,7 +204,9 @@ void AirsimROSWrapper::create_ros_pubs_from_settings_json()
                 lidar_pub_vec_.push_back(nh_.advertise<sensor_msgs::PointCloud2>("lidar/" + sensor_name, 10));
                 lidar_pub_vec_statistics.push_back(ros_bridge::Statistics(sensor_name + "_Publisher"));
                 getLidarDataVecStatistics.push_back(ros_bridge::Statistics(sensor_name + "_RpcCaller"));
-                // statistics_obj_ptr.insert(statistics_obj_ptr.end(), {&lidar_pub_vec_statistics.back(), &getLidarDataVecStatistics.back()});
+
+                ros::TimerOptions timer_options(ros::Duration(float(1) / float(lidar_setting.horizontal_rotation_frequency)), boost::bind(&AirsimROSWrapper::lidar_timer_cb, this, _1), &lidar_timer_cb_queue_);
+                airsim_lidar_update_timers_.push_back(nh_private_.createTimer(timer_options));
                 break;
             }
             default:
@@ -217,29 +217,7 @@ void AirsimROSWrapper::create_ros_pubs_from_settings_json()
         }
     }
 
-    // todo add per vehicle reset in AirLib API
     reset_srvr_ = nh_.advertiseService("reset", &AirsimROSWrapper::reset_srv_cb, this);
-
-    // todo mimic gazebo's /use_sim_time feature which publishes airsim's clock time..via an rpc call?!
-    // clock_pub_ = nh_private_.advertise<rosgraph_msgs::Clock>("clock", 10);
-
-    if (lidar_pub_vec_.size() > 0)
-    {
-        double update_lidar_every_n_sec;
-        nh_private_.getParam("update_lidar_every_n_sec", update_lidar_every_n_sec);
-        // nh_private_.setCallbackQueue(&lidar_timer_cb_queue_);
-        bool separate_spinner = true; // todo debugging race condition
-        if (separate_spinner)
-        {
-            ros::TimerOptions timer_options(ros::Duration(update_lidar_every_n_sec), boost::bind(&AirsimROSWrapper::lidar_timer_cb, this, _1), &lidar_timer_cb_queue_);
-            airsim_lidar_update_timer_ = nh_private_.createTimer(timer_options);
-            is_used_lidar_timer_cb_queue_ = true;
-        }
-        else
-        {
-            airsim_lidar_update_timer_ = nh_private_.createTimer(ros::Duration(update_lidar_every_n_sec), &AirsimROSWrapper::lidar_timer_cb, this);
-        }
-    }
 
     initialize_airsim();
 }
@@ -629,10 +607,8 @@ void AirsimROSWrapper::lidar_timer_cb(const ros::TimerEvent& event)
 {
     try
     {
-        // std::lock_guard<std::recursive_mutex> guard(car_control_mutex_);
         if (lidar_pub_vec_.size() > 0)
         {
-            // std::lock_guard<std::recursive_mutex> guard(lidar_mutex_);
             int ctr = 0;
             for (const std::string lidar_name : lidar_names_vec_)
             {

--- a/settings.json
+++ b/settings.json
@@ -27,15 +27,19 @@
           "SensorType": 3,
           "Enabled": true
         },
-        "LidarCustom": {
+        "Lidar1": {
           "SensorType": 6,
           "Enabled": true,
-          "NumberOfChannels": 16,
-          "PointsPerSecond": 10000,
-          "X": 0,
-          "Y": 0,
-          "Z": -1,
-          "DrawDebugPoints": false
+          "X": 0, "Y": 0, "Z": -1,
+          "Roll": 0, "Pitch": 0, "Yaw" : 0,
+          "NumberOfLasers": 4,
+          "PointsPerScan": 4096,
+          "VerticalFOVUpper": 5,
+          "VerticalFOVLower": -5,
+          "HorizontalFOVStart": -90,
+          "HorizontalFOVEnd": 90,
+          "RotationsPerSecond": 20,
+          "DrawDebugPoints": true
         }
       },
       "Cameras": {

--- a/settings.json
+++ b/settings.json
@@ -44,7 +44,7 @@
         "Lidar2": {
           "SensorType": 6,
           "Enabled": true,
-          "X": 0, "Y": 0, "Z": -1,
+          "X": 0, "Y": 0, "Z": -2,
           "Roll": 0, "Pitch": 0, "Yaw" : 0,
           "NumberOfLasers": 4,
           "PointsPerScan": 4096,

--- a/settings.json
+++ b/settings.json
@@ -38,8 +38,22 @@
           "VerticalFOVLower": -5,
           "HorizontalFOVStart": -90,
           "HorizontalFOVEnd": 90,
-          "RotationsPerSecond": 20,
-          "DrawDebugPoints": true
+          "RotationsPerSecond": 10,
+          "DrawDebugPoints": false
+        },
+        "Lidar2": {
+          "SensorType": 6,
+          "Enabled": true,
+          "X": 0, "Y": 0, "Z": -1,
+          "Roll": 0, "Pitch": 0, "Yaw" : 0,
+          "NumberOfLasers": 4,
+          "PointsPerScan": 4096,
+          "VerticalFOVUpper": 5,
+          "VerticalFOVLower": -5,
+          "HorizontalFOVStart": -90,
+          "HorizontalFOVEnd": 90,
+          "RotationsPerSecond": 5,
+          "DrawDebugPoints": false
         }
       },
       "Cameras": {


### PR DESCRIPTION
* Added more lidar rules as proposed in #127 to prevent unrealistic setups
* Simplify lidar capture model to ease configuration
* split documentation into 'lidar configuration' (see lidar.md) and 'competition rules' (see integration-handbook.md). Should solve #132 
* Fixed bug in lidar debug points where all points where mirrored because ned vs enu frame.
* Renamed setting `NumberOfChannels` to `NumberOfLasers`
* Renamed setting `PointsPerSecond` to `PointsPerScan`
* Removed `startup_delay` configuration as it must always be 0
* Changed the lidar simulation to always do 1 full 360 capture during every update. Before, the time-diff was used to calculate how much the lidar had rotated and capture based on this. This resulted in unexpected behavior when small lag happens causing no points to be collected when using a narrow the field of view. Also, I din't feel like this rotation simulation added much value. I feel like this new model is more robust and simpler to understand without losing any used functionality.