### PR TITLE
added frame to GPS ROS message

### DIFF
--- a/ros/src/fsds_ros_bridge/src/airsim_ros_wrapper.cpp
+++ b/ros/src/fsds_ros_bridge/src/airsim_ros_wrapper.cpp
@@ -395,6 +395,7 @@ sensor_msgs::Imu AirsimROSWrapper::get_imu_msg_from_airsim(const msr::airlib::Im
 sensor_msgs::NavSatFix AirsimROSWrapper::get_gps_sensor_msg_from_airsim_geo_point(const msr::airlib::GeoPoint& geo_point) const
 {
     sensor_msgs::NavSatFix gps_msg;
+    gps_msg.header.frame_id = "fsds/" + vehicle_name;
     gps_msg.latitude = geo_point.latitude;
     gps_msg.longitude = geo_point.longitude;
     gps_msg.altitude = geo_point.altitude;


### PR DESCRIPTION
Similar to how the IMU message is attached to the frame of the car, the GPS should also contain the frame of the car. This is something that was useful to have when implementing an EKF for the MITeamDelft state estimation system.