### PR TITLE
Hotfixes before v1.0.0 release

### DIFF
--- a/AirSim/AirLib/include/sensors/imu/ImuSimple.hpp
+++ b/AirSim/AirLib/include/sensors/imu/ImuSimple.hpp
@@ -52,7 +52,7 @@ private: //methods
         const GroundTruth& ground_truth = getGroundTruth();
 
         output.angular_velocity = ground_truth.kinematics->twist.angular;
-        ground_truth.kinematics->accelerations.linear - Vector3r(0, 0, EarthUtils::Gravity);;
+        output.linear_acceleration = ground_truth.kinematics->accelerations.linear - Vector3r(0, 0, EarthUtils::Gravity);
         output.orientation = ground_truth.kinematics->pose.orientation;
 
         //acceleration is in world frame so transform to body frame

--- a/docs/ros-bridge.md
+++ b/docs/ros-bridge.md
@@ -101,8 +101,12 @@ Transforms to the ground truth are disabled because this would take away the sta
 - `/fsds/ros_bridge/competition_mode` [bool]   
   Set in: `$(fsds_ros_bridge)/launch/fsds_ros_bridge.launch`
   Default: `false`, during competition set to `true`
-  If competition mode is enabled, the `testing_only` topics won't be available. 
-  Also, input from keyboard and joystick to unreal will no longer controll the vehicle.
+  If competition mode is enabled, the `testing_only` topics won't be available.
+
+- `/fsds/ros_bridge/manul_mode` [bool]
+  Set in: `$(fsds_ros_bridge)/launch/fsds_ros_bridge.launch`
+  Default: `false`
+  Do not enable vehicle api control. You can controll the car using the keyboard in the simulator.
 
 ## Visualization
 This package contains some useful launch and config files which will help you in visualizing the data being streamed through the above topics.

--- a/ros/src/examples/scripts/sinewave.py
+++ b/ros/src/examples/scripts/sinewave.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 import rospy, math
-from fsds_ros_bridge.msg import ControlCommand
+from fs_msgs.msg import ControlCommand
 
 # the number of seconds to do a full steering cycle (neutral -> full right -> full left -> neutroal)
 STEERING_PERIOD = 5

--- a/ros/src/fsds_ros_bridge/launch/fsds_ros_bridge.launch
+++ b/ros/src/fsds_ros_bridge/launch/fsds_ros_bridge.launch
@@ -4,6 +4,7 @@
 	<arg name="mission_name" default="trackdrive"/>
 	<arg name="track_name" default="A"/>
 	<arg name="competition_mode" default="false"/>
+	<arg name="manual_mode" default="false"/>
 	<arg name="access_token" default=""/>
 	<arg name="plot" default="false"/>
 	<arg name="rviz" default="false"/>
@@ -24,6 +25,7 @@
 			<param name="mission_name" type="string" value="$(arg mission_name)"/>
 			<param name="track_name" type="string" value="$(arg track_name)"/>
 			<param name="competition_mode" type="bool" value="$(arg competition_mode)" />
+			<param name="manual_mode" type="bool" value="$(arg manual_mode)" />
 			<env name="OPERATOR_ACCESS_TOKEN" value="$(arg access_token)"/>
 		</node>
 

--- a/ros/src/fsds_ros_bridge/src/airsim_ros_wrapper.cpp
+++ b/ros/src/fsds_ros_bridge/src/airsim_ros_wrapper.cpp
@@ -117,15 +117,16 @@ void AirsimROSWrapper::initialize_ros()
     double update_imu_every_n_sec;
     double update_gss_every_n_sec;
     double publish_static_tf_every_n_sec;
+    bool manual_mode;
     nh_private_.getParam("mission_name", mission_name_);
     nh_private_.getParam("track_name", track_name_);
     nh_private_.getParam("competition_mode", competition_mode_);
+    nh_private_.getParam("manual_mode", manual_mode);
     nh_private_.getParam("update_odom_every_n_sec", update_odom_every_n_sec);
     nh_private_.getParam("update_gps_every_n_sec", update_gps_every_n_sec);
     nh_private_.getParam("update_imu_every_n_sec", update_imu_every_n_sec);
     nh_private_.getParam("update_gss_every_n_sec", update_gss_every_n_sec);
     nh_private_.getParam("publish_static_tf_every_n_sec", publish_static_tf_every_n_sec);
-    
 
     create_ros_pubs_from_settings_json();
 
@@ -141,7 +142,7 @@ void AirsimROSWrapper::initialize_ros()
     statistics_timer_ = nh_private_.createTimer(ros::Duration(1), &AirsimROSWrapper::statistics_timer_cb, this);
     go_signal_timer_ = nh_private_.createTimer(ros::Duration(1), &AirsimROSWrapper::go_signal_timer_cb, this);
 
-    airsim_client_.enableApiControl(competition_mode_, vehicle_name);
+    airsim_client_.enableApiControl(!manual_mode, vehicle_name);
     airsim_client_.armDisarm(true, vehicle_name); 
 
     if(!competition_mode_) {


### PR DESCRIPTION
* Add 'manual_mode' in rosbridge that toggles api controll. This was needed because previously competition_mode enabled/disabled api control which caused the car to be not drivable in non-competition mode
* Fix bug where IMU linear acceleration was going exponentially high
* Fix sinewave.py message reference