### PR TITLE
Enable CCD on cones to prevent cones falling though world.

### DIFF
--- a/UE4Project/Content/RaceCourse/Model/Splines/spline_cones.uasset
+++ b/UE4Project/Content/RaceCourse/Model/Splines/spline_cones.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5eb5b2b02051f1325fb8843721bbc665ff6b9d19420ebb9f4fb561b70c1419ca
-size 217588
+oid sha256:53e09495a9797a63e947d063bbb62794fc3719ad137afc1ba65b7448cd8ce407
+size 222045


### PR DESCRIPTION
Fixes #212